### PR TITLE
Update teamcity formatter for cucumber

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,9 +1,8 @@
 == A basic Cucumber Formatter for TeamCity
 
-Tested with {Cucumber}[http://github.com/aslakhellesoy/cucumber/tree] 0.2.3 -> 0.3.6 and {TeamCity}[http://www.jetbrains.com/teamcity/index.html] 4.0.2 and 4.5.x.
+Tested with {Cucumber}[http://github.com/aslakhellesoy/cucumber/tree] 1.3.18 and {TeamCity}[http://www.jetbrains.com/teamcity/index.html] 8.x.x.
 
-Apparently, TeamCity 5.x will have native cucumber support, obviating this formatter. But I'll leave it here
-for people who still run 4.x.
+Although teamcity has native support but the default formatter interprets every step as a separate test which does not reflect reality.
 
 == Install
 
@@ -31,11 +30,11 @@ not not just the numbers in the table.
 
 == Notes
 
-
 We are not necessarily using all the features of cucumber in house,
 so please feel free to submit patches.
 
 == License
 Do what you will, but give credit.
 
-darrell [at] garnix.org
+darrell [at] garnix.org <- Original author
+ankur [at] malloc64.com

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,6 +1,6 @@
 == A basic Cucumber Formatter for TeamCity
 
-Tested with {Cucumber}[http://github.com/aslakhellesoy/cucumber/tree] 1.3.18 and {TeamCity}[http://www.jetbrains.com/teamcity/index.html] 8.x.x.
+Tested with {Cucumber}[http://github.com/cucumber/cucumber] 1.3.18 and {TeamCity}[http://www.jetbrains.com/teamcity/index.html] 8.x.x.
 
 Although teamcity has native support but the default formatter interprets every step as a separate test which does not reflect reality.
 

--- a/teamcity_formatter.rb
+++ b/teamcity_formatter.rb
@@ -25,7 +25,7 @@ class TeamCityFormatter < Cucumber::Ast::Visitor
   # Hook for new feature.
   # Because cucumber does not provide begin and end hooks,
   # we store the feature name and issue a Finished when it changes
-  def visit_feature_name(name)
+  def feature_name(name)
     name=name.split("\n").first
     @current_feature=name if @current_feature.nil?
     if name != @current_feature
@@ -35,13 +35,13 @@ class TeamCityFormatter < Cucumber::Ast::Visitor
     feature_start(@current_feature)
   end
 
-  def visit_exception(exception, status)
+  def exception(exception, status)
     test_failure(@current_step,format_exception(exception)) if status == :failed
   end
 
   # put each step into the messages buffer. Because of the way teamcity formats
   # output, we want to output all our messages at the same time
-  def visit_step_name(keyword, step_match, status, source_indent, background)
+  def step_name(keyword, step_match, status, source_indent, background)
     line=format_step(keyword, step_match, status)
     @current_step=line
     if status != :passed
@@ -60,7 +60,7 @@ class TeamCityFormatter < Cucumber::Ast::Visitor
     )
   end
 
-  def visit_scenario_name(keyword, name, file_colon_line, source_indent)
+  def scenario_name(keyword, name, file_colon_line, source_indent)
     visit_feature_element_name(keyword, name, file_colon_line, source_indent)
   end
 
@@ -80,13 +80,11 @@ class TeamCityFormatter < Cucumber::Ast::Visitor
     scenario_start(line)
   end
   
-  def visit_outline_table(outline_table)
+  def before_outline_table(outline_table)
     step_message("#{timestamp_short} running outline: ")
-    super
   end
 
-  def visit_table_row(table_row)
-    super
+  def after_table_row(table_row)
     if table_row.exception
       test_failure(format_table_row(table_row, :failed),format_exception(table_row.exception))
     else


### PR DESCRIPTION
The old format no longer works with current cucumber versions. This edit basically gets thing running again.