### PR TITLE
Fix feature_name arguments

### DIFF
--- a/teamcity_formatter.rb
+++ b/teamcity_formatter.rb
@@ -19,7 +19,7 @@ class TeamCityFormatter
     end
   end
 
-  def feature_name(name, something)
+  def feature_name(keyword, name)
     name=name.split("\n").first
     @current_feature=name if @current_feature.nil?
     if name != @current_feature


### PR DESCRIPTION
The `feature_name` method expects `keyword` and `name` arguments;
`keyword` is typically the string "Feature", while `name` is the actual
feature name (what follows "Feature:" at the top of a .feature file).

Before this fix, the teamcity formatter was emitting multiple
`testSuiteStarted` markers with `name='Feature'`, but never any
corresponding `testSuiteFinished` markers (since the "feature name" was
always the same, "Feature"). For example:

    ##teamcity[testSuiteStarted name='Feature']
    ##teamcity[testSuiteStarted name='Feature']
    ##teamcity[testSuiteStarted name='Feature']
    ...

After this fix, I correctly get e.g.:

    ##teamcity[testSuiteStarted name='Login']
    ##teamcity[testSuiteFinished name='Login']

    ##teamcity[testSuiteStarted name='Logout']
    ##teamcity[testSuiteFinished name='Logout']